### PR TITLE
Some guards for building different sbnanaobj versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ elseif(NOT DEFINED CMAKE_INSTALL_PREFIX)
 endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "")
-  set(CMAKE_BUILD_TYPE DebWithRelInfo)
+  set(CMAKE_BUILD_TYPE RelWithDebInfo)
 endif()
 
 find_package(nusystematics 2.00.01 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,11 +32,11 @@ if(NOT TARGET GENIE3::All)
 endif()
 
 find_package(sbnanaobj 09.20.06.03 REQUIRED)
-# Detect sbnanaobj version and set flag for kMultiSim (<= 10.05.00) or kMultisim
+# Detect sbnanaobj version and set flag for kMultisim or kMultiSim
 set(_raw_sbnanaobj_version "$ENV{SBNANAOBJ_VERSION}")
 string(REGEX REPLACE "^v" "" _sbnanaobj_ver_underscores "${_raw_sbnanaobj_version}")
 string(REPLACE "_" "." SBNANAOBJ_VERSION "${_sbnanaobj_ver_underscores}")
-if(SBNANAOBJ_VERSION VERSION_LESS "10.00.05.01")
+if(SBNANAOBJ_VERSION VERSION_LESS "10.00.05.01" OR SBNANAOBJ_VERSION VERSION_GREATER_EQUAL "10.00.06")
   set(SBNANAOBJ_KMULTISIM_CAP ON)
 else()
   set(SBNANAOBJ_KMULTISIM_CAP OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@ find_program(CMAKE_CXX_COMPILER NAMES $ENV{CXX} g++ PATHS ENV PATH NO_DEFAULT_PA
 
 set(CMAKE_CXX_STANDARD 17)
 
+if(DEFINED ENV{CMAKE_MODULE_PATH})
+  string(REPLACE ":" ";" _module_path "$ENV{CMAKE_MODULE_PATH}")
+  list(APPEND CMAKE_MODULE_PATH ${_module_path})
+endif()
+
 project(sbnnusyst VERSION 1.00.00 LANGUAGES CXX)
 
 #Changes default install path to be a subdirectory of the build dir.
@@ -21,10 +26,20 @@ if(CMAKE_BUILD_TYPE STREQUAL "")
 endif()
 
 find_package(nusystematics 2.00.01 REQUIRED)
-find_package(sbnanaobj 09.20.06.03 REQUIRED)
 find_package(GENIE3 REQUIRED)
 if(NOT TARGET GENIE3::All)
   message(FATAL_ERROR "Expected find_package(GENIE3 REQUIRED) call to set up target GENIE3::All.")
+endif()
+
+find_package(sbnanaobj 09.20.06.03 REQUIRED)
+# Detect sbnanaobj version and set flag for kMultiSim (<= 10.05.00) or kMultisim
+set(_raw_sbnanaobj_version "$ENV{SBNANAOBJ_VERSION}")
+string(REGEX REPLACE "^v" "" _sbnanaobj_ver_underscores "${_raw_sbnanaobj_version}")
+string(REPLACE "_" "." SBNANAOBJ_VERSION "${_sbnanaobj_ver_underscores}")
+if(SBNANAOBJ_VERSION VERSION_LESS "10.00.05.01")
+  set(SBNANAOBJ_KMULTISIM_CAP ON)
+else()
+  set(SBNANAOBJ_KMULTISIM_CAP OFF)
 endif()
 
 ## Check if we have fhiclcpp from ups

--- a/src/sbnnusyst/interface/CMakeLists.txt
+++ b/src/sbnnusyst/interface/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(sbnnusyst::interface ALIAS sbnnusyst_interface)
 set_target_properties(sbnnusyst_interface PROPERTIES 
   PUBLIC_HEADER "${IFCE_HDRFILES}"
   EXPORT_NAME interface )
+target_compile_definitions(sbnnusyst_interface PRIVATE $<$<BOOL:${SBNANAOBJ_KMULTISIM_CAP}>:SBNANAOBJ_KMULTISIM_CAP>)
 
 target_link_libraries(sbnnusyst_interface
 PUBLIC

--- a/src/sbnnusyst/interface/WeightUpdater.cxx
+++ b/src/sbnnusyst/interface/WeightUpdater.cxx
@@ -407,8 +407,11 @@ void WeightUpdater::CreateGlobalTree(caf::SRGlobal* input_srglobal){
     printf("[WeightUpdater::CreateGlobalTree] Adding %s to globalTree\n", srglobal.wgts.back().name.c_str());
 
     // TODO
+#ifdef SBNANAOBJ_KMULTISIM_CAP
     srglobal.wgts.back().type = sph.isRandomlyThrown ? caf::kMultiSim : caf::kMultiSigma;
-
+#else 
+    srglobal.wgts.back().type = sph.isRandomlyThrown ? caf::kMultisim : caf::kMultiSigma;
+#endif
     // Weight map entry (e.g., dep dials)
     auto it = map_resp_to_respless.find( sph.systParamId );
 


### PR DESCRIPTION
Adds a check for `kMultiSim` (sbnanaobj <= v10_00_05 or sbnanaobj >= v10_00_06) vs `kMultisim` (sbnanaobj v10_00_05_*).
Also adds a check to the top-level CMakeLists for `ENV{CMAKE_MODULE_PATH}` and appends it to the CMake project's CMAKE_MODULE_PATH. This is designed to automatically pick up the CMAKE_MODULE_PATH defined by UPS'ified `cmakemodules`.