### PR TITLE
Deattach ROOT histograms

### DIFF
--- a/src/sbnnusyst/app/UpdateReweight.cxx
+++ b/src/sbnnusyst/app/UpdateReweight.cxx
@@ -115,6 +115,9 @@ int main(int argc, char const *argv[]) {
     return 1;
   }
 
+  // Detach ownership of histograms
+  TH1::AddDirectory(kFALSE);
+
   std::ifstream inputFile(cliopts::input_filename);
   if(!inputFile.is_open()){
     printf("[ERROR] %s does not exist\n", cliopts::input_filename);


### PR DESCRIPTION
Because some histograms in nusystematics are kept in `gDirectory` (looking at you, QEInterference...), without an explicit call to `TH1::AddDirectory(kFALSE)`, they end up in the output of `UpdateReweight`. This fixes that.